### PR TITLE
Package name has changed

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM python:3.5
 RUN apt-get update
-RUN apt-get install -y make python-software-properties curl
+RUN apt-get install -y make software-properties-common curl
 RUN curl -sL https://deb.nodesource.com/setup_7.x | bash -
 RUN apt-get update
 RUN apt-get install -y nodejs libldap2-dev libsasl2-dev libldap2-dev libssl-dev


### PR DESCRIPTION
python-software-properties was renamed to software-properties-common
https://askubuntu.com/questions/422975/e-package-python-software-properties-has-no-installation-candidate